### PR TITLE
make missing icons use the oh no image.

### DIFF
--- a/src/mindustry-mods.py
+++ b/src/mindustry-mods.py
@@ -283,7 +283,7 @@ class ModMeta:
 
 
     def icon_url(self):
-        return f"https://raw.githubusercontent.com/{self.repo}/master/{self.icon_raw}"
+        return f"https://raw.githubusercontent.com/{self.repo}/master/{self.icon_raw}" if self.icon_raw else "https://raw.githubusercontent.com/Anuken/Mindustry/master/core/assets/sprites/error.png"
 
     def readme_html(self):
         from markdown import markdown


### PR DESCRIPTION
in theory when the mods list is generated, it will put https://raw.githubusercontent.com/Anuken/Mindustry/master/core/assets/sprites/error.png as a placeholder if no icon is provided after this change. (i cant test right now but i will as soon as i have access to a device with python.