### PR TITLE
Add hover star count

### DIFF
--- a/src/templates/listing.html
+++ b/src/templates/listing.html
@@ -39,7 +39,7 @@
         </p>
       </td>
       <td class="delta">{{ mod.delta_ago() }} ago</td>
-      <td class="stars">{{ mod.stars_fmt() }}</td>
+      <td class="stars" title={{ mod.stars }}>{{ mod.stars_fmt() }}</td>
     <tr/>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
should now tell you how many stars a mod has when hovering over the stars so you dont have to count on mods like exampleMod with 30+ stars